### PR TITLE
fix boss batlle

### DIFF
--- a/data/tutorialData.json
+++ b/data/tutorialData.json
@@ -1,3 +1,3 @@
 {
-	"tutorial_completed": false
+	"tutorial_completed": true
 }

--- a/scenes/UI/battle.tscn
+++ b/scenes/UI/battle.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="FontFile" uid="uid://d4fqcjicieold" path="res://assets/font/PixelPurl.ttf" id="4_jvqxm"]
 [ext_resource type="Texture2D" uid="uid://cpyoj2ajuoijt" path="res://assets/menu/UI_TravelBook_Marker01a.png" id="5_dxtsq"]
 [ext_resource type="Texture2D" uid="uid://ceidsb110q7ug" path="res://assets/menu/UI_TravelBook_Marker01a inverted.png" id="6_gwqu3"]
-[ext_resource type="Shader" path="res://shaders/round_corners.gdshader" id="7_e8pcg"]
+[ext_resource type="Shader" uid="uid://bhllwj1vey6kg" path="res://shaders/round_corners.gdshader" id="7_e8pcg"]
 [ext_resource type="Texture2D" uid="uid://bkugys8878hd" path="res://assets/testsprites/placeholder_floornwall_goodsize.png" id="8_ryxhp"]
 [ext_resource type="Texture2D" uid="uid://p1r7l118n6so" path="res://assets/map-tiles/16x16 dungeon ii wall reconfig v04 spritesheet.png" id="9_qf25x"]
 [ext_resource type="Texture2D" uid="uid://dasnbfy8q0ie" path="res://assets/fight_animations/player_2hit.png" id="10_tqc8e"]

--- a/scenes/sprite_scenes/necromancer_scene.tscn
+++ b/scenes/sprite_scenes/necromancer_scene.tscn
@@ -54,6 +54,7 @@ animations = [{
 }]
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" unique_id=358690754]
+position = Vector2(-16, -16)
 sprite_frames = SubResource("SpriteFrames_7ojl6")
 animation = &"idle"
 frame = 4

--- a/scenes/sprite_scenes/wendigo_sprite_scene.tscn
+++ b/scenes/sprite_scenes/wendigo_sprite_scene.tscn
@@ -39,7 +39,6 @@ animations = [{
 }]
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" unique_id=366324882]
-position = Vector2(2, 7)
 sprite_frames = SubResource("SpriteFrames_xtrj1")
 animation = &"idle"
 frame_progress = 0.39585075

--- a/scripts/UI/battle_script.gd
+++ b/scripts/UI/battle_script.gd
@@ -2,6 +2,7 @@ extends CanvasLayer
 
 signal player_loss
 signal player_victory
+signal player_vicory_boss
 
 const MARKER_PREFAB := preload("res://scenes/rooms/helpers/marker.tscn")
 const MARKER_FLAVOURS = {
@@ -58,6 +59,7 @@ var active: bool = true
 var enemy_action_log = []
 var player_action_log = []
 
+var enemy_is_boss = false
 @onready var hit_anim_enemy: AnimatedSprite2D = $Battle_root/PlayerPosition/enemy_attack_anim
 @onready var hit_anim_player: AnimatedSprite2D = $Battle_root/EnemyPosition/player_attack_anim
 @onready var enemy_marker = $Battle_root/EnemyPosition
@@ -75,6 +77,7 @@ func _ready():
 		player.full_status_heal()
 	if enemy != null and is_instance_valid(enemy):
 		enemy.full_status_heal()
+		enemy_is_boss = enemy.boss
 	enemy_sprite = create_battle_sprite(enemy)
 	player_sprite = create_battle_sprite(player)
 	player_sprite.animation = "idle_up"

--- a/scripts/entity/enemy_vampire_bat.gd
+++ b/scripts/entity/enemy_vampire_bat.gd
@@ -8,7 +8,7 @@ var chase_timer: float = 5.0
 var burrowed = false
 var chased_pos: Vector2i
 var chased_direction: Vector2i
-
+var boss: bool = false
 var chosen: Skill
 var sprite_type: String = "bat"
 var behaviour = "idle"

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -36,7 +36,7 @@ var loading_screen: CanvasLayer = null
 
 var switching_world := false
 
-var boss_win : bool = false
+var boss_win: bool = false
 
 @onready var backgroundtile = $TileMapLayer
 
@@ -852,7 +852,9 @@ func spawn_enemies(do_boss: bool) -> void:
 			print("spawn: ", def.get("sprite_type", id))
 
 
-func spawn_enemy(sprite_type: String, behaviour: Array, skills: Array, stats: Dictionary, boss: bool = false) -> void:
+func spawn_enemy(
+	sprite_type: String, behaviour: Array, skills: Array, stats: Dictionary, boss: bool = false
+) -> void:
 	# default: spawn normal enemy
 	var e = ENEMY_SCENE.instantiate()
 	e.add_to_group("enemy")

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -36,6 +36,8 @@ var loading_screen: CanvasLayer = null
 
 var switching_world := false
 
+var boss_win : bool = false
+
 @onready var backgroundtile = $TileMapLayer
 
 @onready var minimap: TileMapLayer
@@ -73,6 +75,9 @@ func _load_tutorial_world() -> void:
 	await _show_loading()
 
 	_clear_world()
+
+	# Reset boss flag when loading a world so previous boss state doesn't leak
+	boss_win = false
 
 	world_root = Node2D.new()
 	world_root.name = "WorldRoot"
@@ -622,6 +627,14 @@ func _on_player_exit_reached() -> void:
 	if switching_world:
 		return
 
+	# Prevent progressing if a boss is still alive in the world
+	for e in get_tree().get_nodes_in_group("enemy"):
+		if e != null and is_instance_valid(e):
+			# enemies spawned by spawn_enemy have a `boss` property
+			if bool(e.boss) and e.hp > 0:
+				push_warning("You must defeat the boss before advancing!")
+				return
+
 	switching_world = true
 
 	# Prüfen: Sind wir im Tutorial? (Tutorial hat keine Minimap)
@@ -785,7 +798,8 @@ func spawn_enemies(do_boss: bool) -> void:
 			def.get("sprite_type", "what"),
 			def.get("behaviour", []),
 			def.get("skills", []),
-			def.get("stats", {})
+			def.get("stats", {}),
+			true
 		)
 		print("Spawned boss!")
 		return
@@ -838,7 +852,7 @@ func spawn_enemies(do_boss: bool) -> void:
 			print("spawn: ", def.get("sprite_type", id))
 
 
-func spawn_enemy(sprite_type: String, behaviour: Array, skills: Array, stats: Dictionary) -> void:
+func spawn_enemy(sprite_type: String, behaviour: Array, skills: Array, stats: Dictionary, boss: bool = false) -> void:
 	# default: spawn normal enemy
 	var e = ENEMY_SCENE.instantiate()
 	e.add_to_group("enemy")
@@ -847,6 +861,7 @@ func spawn_enemy(sprite_type: String, behaviour: Array, skills: Array, stats: Di
 	e.types = behaviour
 	e.sprite_type = sprite_type
 	e.abilities_this_has = skills
+	e.boss = boss
 	var hp = stats.get("hp", 1)
 	var str = stats.get("str", 1)
 	var def = stats.get("def", 1)
@@ -1053,6 +1068,11 @@ func enemy_defeated(enemy):
 		print("enemy_defeated: freeing battle UI")
 		battle.call_deferred("queue_free")
 		battle = null
+
+	# If the defeated enemy was a boss, record victory so level-gating can proceed
+	if enemy != null and is_instance_valid(enemy) and bool(enemy.boss):
+		boss_win = true
+		print("enemy_defeated: boss defeated -> boss_win set to true")
 
 	if enemy != null and is_instance_valid(enemy):
 		print("enemy_defeated: freeing enemy node")


### PR DESCRIPTION
This pull request introduces a boss mechanic to the game, ensuring that players must defeat a boss enemy before advancing to the next level. It adds a `boss` property to enemies, tracks boss defeat status, and updates relevant scripts to enforce this new gating logic.

**Boss Mechanic Implementation:**

* Added a `boss` property to enemy entities, allowing certain enemies to be designated as bosses (`enemy_vampire_bat.gd`).
* Updated enemy spawning logic to accept and set the `boss` flag, ensuring that bosses are properly instantiated and tracked (`main.gd`). [[1]](diffhunk://#diff-198c8e8743a48a51567e04d3cef190771ad041bee3e22bb4526779daad15e531L788-R802) [[2]](diffhunk://#diff-198c8e8743a48a51567e04d3cef190771ad041bee3e22bb4526779daad15e531L841-R855) [[3]](diffhunk://#diff-198c8e8743a48a51567e04d3cef190771ad041bee3e22bb4526779daad15e531R864)

**Level Progression Gating:**

* Modified the exit logic to prevent players from progressing to the next level if a boss enemy is still alive, displaying a warning if so (`main.gd`).
* Added a `boss_win` flag to track boss defeat, resetting it when loading a new world and setting it upon boss defeat (`main.gd`). [[1]](diffhunk://#diff-198c8e8743a48a51567e04d3cef190771ad041bee3e22bb4526779daad15e531R39-R40) [[2]](diffhunk://#diff-198c8e8743a48a51567e04d3cef190771ad041bee3e22bb4526779daad15e531R79-R81) [[3]](diffhunk://#diff-198c8e8743a48a51567e04d3cef190771ad041bee3e22bb4526779daad15e531R1072-R1076)

**UI and Battle Scene Updates:**

* Updated the battle scene and script to support boss status, including a new signal for boss victory and tracking if the current enemy is a boss (`battle_script.gd`, `battle.tscn`). [[1]](diffhunk://#diff-9cedd2af0e2a7a0208809baabd1499290837c67ed41eb8751f39359f805a4784R5) [[2]](diffhunk://#diff-9cedd2af0e2a7a0208809baabd1499290837c67ed41eb8751f39359f805a4784R62) [[3]](diffhunk://#diff-9cedd2af0e2a7a0208809baabd1499290837c67ed41eb8751f39359f805a4784R80) [[4]](diffhunk://#diff-ab3202ac4d271a1b598059c34ae59deb48ada263efcf67e1f9bf6cc664d1fbc1L9-R9)

**Tutorial Data Update:**

* Marked the tutorial as completed in `tutorialData.json`.