### PR TITLE
244

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ Behavior:
   "group": "Weapon",
   "weight": 3,
   "merchant": {
-    "min_count": 1,
-    "max_count": 2,
-    "min_price": 6,
-    "max_price": 9,
-    "buy_amount": 2,
-    "chance": 1.0,
-    "weight": 1
+	"min_count": 1,
+	"max_count": 2,
+	"min_price": 6,
+	"max_price": 9,
+	"buy_amount": 2,
+	"chance": 1.0,
+	"weight": 1
   },
   "bound_skills": ["Slash"],
 	"range":"short"

--- a/data/tutorialData.json
+++ b/data/tutorialData.json
@@ -1,3 +1,3 @@
 {
-	"tutorial_completed": true
+	"tutorial_completed": false
 }

--- a/data/tutorialData.json
+++ b/data/tutorialData.json
@@ -1,3 +1,3 @@
 {
-	"tutorial_completed": false
+	"tutorial_completed": true
 }

--- a/scripts/Mapgenerator/map_generator_modular.gd
+++ b/scripts/Mapgenerator/map_generator_modular.gd
@@ -58,7 +58,7 @@ var room_id: int = 0
 # Private
 var _closed_door_cache: Dictionary = {}
 var _corridor_cache: Dictionary = {}
-var _rng := GlobalRNG.get_rng()
+var _rng = null
 var _yield_counter := 0
 
 
@@ -132,6 +132,9 @@ func get_random_tilemap() -> Dictionary:
 	_yield_counter = 0
 	_emit_progress_mapped(0.0, 0.05, 0.0, "Preparing scenes...")
 	await get_tree().process_frame
+
+	# Ensure RNG is seeded fresh for this generation (deterministic per GlobalRNG reset)
+	_rng = GlobalRNG.get_rng()
 
 	# load/start scenes
 	start_room = load("res://scenes/rooms/Rooms/room_11x11_4.tscn")

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -683,6 +683,10 @@ func _clear_world() -> void:
 	if EntityAutoload != null and EntityAutoload.has_method("reset"):
 		EntityAutoload.reset()
 
+	# Reset global RNG to base seed so new-world generation is deterministic
+	if typeof(GlobalRNG) != TYPE_NIL and GlobalRNG != null and GlobalRNG.has_method("reset"):
+		GlobalRNG.reset()
+
 
 func _on_player_exit_reached() -> void:
 	if switching_world:
@@ -834,8 +838,8 @@ func spawn_enemies(do_boss: bool) -> void:
 		total = float(weights.size())
 
 	# --- Spawn-Plan erstellen ---
+	# Use a fresh RNG from GlobalRNG (get_rng already seeds with next_seed())
 	var rng := GlobalRNG.get_rng()
-	rng.seed = GlobalRNG.next_seed()
 
 	var current_weight := 0
 	var spawn_plan := {}


### PR DESCRIPTION
This pull request introduces improvements to the game's random number generation, ensuring deterministic world and enemy generation by properly resetting and seeding the global RNG. Additionally, it marks the tutorial as completed in the data file. The most important changes are grouped below:

Random Number Generation Improvements:

* [`scripts/main.gd`](diffhunk://#diff-198c8e8743a48a51567e04d3cef190771ad041bee3e22bb4526779daad15e531R686-R689): Added logic in `_clear_world()` to reset the global RNG (`GlobalRNG.reset()`), ensuring deterministic world generation when starting a new world.
* [`scripts/Mapgenerator/map_generator_modular.gd`](diffhunk://#diff-253ffa40afa9e927527c7a8d965aa3f3bd369d6abce64a5ce077808280b4266aL61-R61): Changed `_rng` initialization to `null` and now explicitly assigns a fresh RNG instance from `GlobalRNG.get_rng()` in `get_random_tilemap()`, guaranteeing consistent seeding for each map generation. [[1]](diffhunk://#diff-253ffa40afa9e927527c7a8d965aa3f3bd369d6abce64a5ce077808280b4266aL61-R61) [[2]](diffhunk://#diff-253ffa40afa9e927527c7a8d965aa3f3bd369d6abce64a5ce077808280b4266aR136-R138)
* [`scripts/main.gd`](diffhunk://#diff-198c8e8743a48a51567e04d3cef190771ad041bee3e22bb4526779daad15e531R841-L838): Updated `spawn_enemies()` to use a freshly seeded RNG from `GlobalRNG.get_rng()`, removing manual seeding and relying on the RNG's internal seeding logic.

Data Update:

* [`data/tutorialData.json`](diffhunk://#diff-618893f36298c9f169cf0af0af512bd1e1ee9b891d00c60ee1f98231ef62788cL2-R2): Marked the tutorial as completed by setting `"tutorial_completed"` to `true`.