### PR TITLE
half fix

### DIFF
--- a/assets/films/31851-389009390_tiny-_1_ (1).ogv.uid
+++ b/assets/films/31851-389009390_tiny-_1_ (1).ogv.uid
@@ -1,0 +1,1 @@
+uid://cqmrwaikqhgak

--- a/data/tutorialData.json
+++ b/data/tutorialData.json
@@ -1,3 +1,3 @@
 {
-	"tutorial_completed": true
+	"tutorial_completed": false
 }

--- a/data/tutorialData.json
+++ b/data/tutorialData.json
@@ -1,3 +1,3 @@
 {
-	"tutorial_completed": false
+	"tutorial_completed": true
 }

--- a/scenes/entity/player-character-scene.tscn
+++ b/scenes/entity/player-character-scene.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://7bogatxmpx0w" path="res://scripts/entity/player_character.gd" id="1_no27k"]
 [ext_resource type="Script" uid="uid://cnto6kvd27me0" path="res://scripts/entity/player_camera.gd" id="4_0cvhd"]
 [ext_resource type="Script" uid="uid://b6h67fqu48631" path="res://scripts/UI/minicam_canvaslayer.gd" id="4_x2d4g"]
+[ext_resource type="VideoStream" uid="uid://cqmrwaikqhgak" path="res://assets/films/31851-389009390_tiny-_1_ (1).ogv" id="5_8pyq6"]
 [ext_resource type="Script" uid="uid://0svglffharts" path="res://scripts/UI/player_inventory_ui.gd" id="5_jmui6"]
 [ext_resource type="Script" uid="uid://cw2q837r7w1po" path="res://scripts/entity/pickup_zone.gd" id="8_jjy7y"]
 [ext_resource type="FontFile" uid="uid://d4fqcjicieold" path="res://assets/font/PixelPurl.ttf" id="9_6k8oa"]
@@ -51,6 +52,25 @@ grow_vertical = 2
 handle_input_locally = false
 size = Vector2i(100, 100)
 render_target_update_mode = 4
+
+[node name="VideoStreamPlayer" type="VideoStreamPlayer" parent="CanvasLayer/SubViewportContainer/SubViewport" unique_id=451452926]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -629.0
+offset_top = -376.0
+offset_right = 1291.0
+offset_bottom = 704.0
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(0.6, 0.6)
+stream = ExtResource("5_8pyq6")
+volume_db = -80.0
+speed_scale = 0.181
+autoplay = true
+loop = true
 
 [node name="MiniCam" type="Camera2D" parent="CanvasLayer/SubViewportContainer/SubViewport" unique_id=1332466115]
 zoom = Vector2(0.2, 0.2)

--- a/scripts/entity/player_character.gd
+++ b/scripts/entity/player_character.gd
@@ -26,6 +26,7 @@ var _binds_and_menus_layer: CanvasLayer = null
 
 @onready var camera: Camera2D = $Camera2D
 @onready var minimap_viewport: SubViewport = $CanvasLayer/SubViewportContainer/SubViewport
+@onready var minimap_video: VideoStreamPlayer = $CanvasLayer/SubViewportContainer/SubViewport/VideoStreamPlayer
 @onready var pickup_ui = $CanvasLayer2
 @onready var inventory = $UserInterface/Inventory
 #@export var binds_and_menus: PackedScene
@@ -116,6 +117,12 @@ func set_minimap(mm: TileMapLayer) -> void:
 		minimap.get_parent().remove_child(minimap)
 
 	minimap_viewport.add_child(minimap)
+
+	# Wenn mehr als ein Kind (z.B. Minimap + VideoStreamPlayer), dann VideoStreamPlayer ausblenden
+	if minimap_viewport.get_child_count() > 1 and minimap_video != null:
+		minimap_video.visible = false
+	elif minimap_video != null:
+		minimap_video.visible = true
 
 
 # --- Input Handling with Cooldown ---

--- a/scripts/entity/player_character.gd
+++ b/scripts/entity/player_character.gd
@@ -26,7 +26,8 @@ var _binds_and_menus_layer: CanvasLayer = null
 
 @onready var camera: Camera2D = $Camera2D
 @onready var minimap_viewport: SubViewport = $CanvasLayer/SubViewportContainer/SubViewport
-@onready var minimap_video: VideoStreamPlayer = $CanvasLayer/SubViewportContainer/SubViewport/VideoStreamPlayer
+@onready
+var minimap_video: VideoStreamPlayer = $CanvasLayer/SubViewportContainer/SubViewport/VideoStreamPlayer
 @onready var pickup_ui = $CanvasLayer2
 @onready var inventory = $UserInterface/Inventory
 #@export var binds_and_menus: PackedScene


### PR DESCRIPTION
This pull request introduces a new video overlay feature to the player character scene and updates the tutorial completion status. The main changes involve adding a `VideoStreamPlayer` node to the minimap viewport, integrating a video asset, and updating the logic to toggle the video visibility depending on the minimap state.

**Video overlay integration:**

* Added a new `VideoStreamPlayer` node to the minimap viewport in `player-character-scene.tscn`, configured to autoplay and loop the video asset.
* Registered the video asset `31851-389009390_tiny-_1_ (1).ogv` as an external resource and referenced it in the scene. [[1]](diffhunk://#diff-cc74630b5bc36a2a14ed08678d4243a86bf5dec80af7a9805596091e1088a45bR6) [[2]](diffhunk://#diff-a1edd751dfb9eaaa97479502ad0daa0fb58bfba2f290275d20dd29fbccc0d2cbR1)
* Added an `onready` variable for the `VideoStreamPlayer` in `player_character.gd` to allow script access.

**Minimap and video visibility logic:**

* Updated `set_minimap` method in `player_character.gd` to toggle the visibility of the video overlay based on the number of children in the minimap viewport. If both minimap and video are present, the video is hidden; otherwise, it is shown.

**Tutorial progress update:**

* Changed `tutorial_completed` from `false` to `true` in `tutorialData.json` to indicate the tutorial has been finished.